### PR TITLE
Add custom validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Register [validations](#PathFormValidation) for this field.
   validations={[
     { type: 'required', message: 'This person must have a name.' },
     { type: 'maxLength', value: 16, message: 'This must be less than 16 characters.' },
+    { type: 'custom', value: (value) => value.trim().toLowerCase() !== 'joe', message: 'This person can\'t be Joe.' },
   ]}
   render={({ inputProps, meta }) => {
     return (
@@ -373,7 +374,8 @@ type PathFormInputProps = {
 type PathFormValidation =
   | { type: 'required'; message: string }
   | { type: 'minLength' | 'maxLength' | 'min' | 'max'; value: number; message: string }
-  | { type: 'regex'; value: RegExp; message: string };
+  | { type: 'regex'; value: RegExp; message: string }
+  | { type: 'custom'; value: (value: any, store?: any) => boolean; message: string };
 ```
 
 ### PathFormError

--- a/example/src/ExampleApp.tsx
+++ b/example/src/ExampleApp.tsx
@@ -21,9 +21,17 @@ export const ExampleApp = () => {
     <PathFormProvider initialRenderValues={fetchedData}>
       <div style={{ display: 'flex', height: '100vh' }}>
         <div style={{ width: 800, padding: 25 }}>
+          <div style={{ marginBottom: 50 }}>
+            <h2>Validations</h2>
+            <ul>
+              <li>Must have a name</li>
+              <li>Name can't be 'Joe'</li>
+              <li>Age must be 21 or older</li>
+            </ul>
+          </div>
           <MyForm />
         </div>
-        <aside style={{ flex: 1, overflowY: 'scroll' }}>
+        <aside style={{ flex: 1, overflowY: 'scroll', padding: 25 }}>
           <PathFormDevTools />
         </aside>
       </div>
@@ -57,7 +65,10 @@ const MyForm = () => {
               <PathFormField
                 path={[...itemPath, 'name']}
                 defaultValue=""
-                validations={[{ type: 'required', message: 'Must give a name.' }]}
+                validations={[
+                  { type: 'required', message: 'Must give a name.' },
+                  { type: 'custom', message: "Name can't be Joe", value: (name) => name.trim().toLowerCase() !== 'joe' },
+                ]}
                 render={({ inputProps, meta, renders }) => {
                   return (
                     <>

--- a/src/PathFormField.test.tsx
+++ b/src/PathFormField.test.tsx
@@ -3,62 +3,135 @@ import { getByLabelText, getByTestId, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PathFormProvider } from './usePathForm';
 import { PathFormField } from './PathFormField';
+import { PathForm } from './PathForm';
 
 const TestWrapper: React.FC = ({ children }) => {
   return (
-    <PathFormProvider initialRenderValues={{ nested: { items: [{ name: 'Joey Joe Joe Jr. Shabadoo' }] } }}>{children}</PathFormProvider>
+    <PathFormProvider initialRenderValues={{ nested: { items: [{ name: 'Joey Joe Joe Jr. Shabadoo' }] } }}>
+      <PathForm onSubmit={() => null}>
+        {children}
+        <button type="submit" data-testid="submit">
+          Submit
+        </button>
+      </PathForm>
+    </PathFormProvider>
   );
 };
 
 describe('PathFormField', () => {
   let container: HTMLElement;
 
-  beforeEach(() => {
-    ({ container } = render(
-      <PathFormField
-        path={['nested', 'items', 0, 'name']}
-        defaultValue="default"
-        render={({ inputProps, meta, renders }) => {
-          return (
-            <div>
-              <label htmlFor="name">Name</label>
-              <input id="name" {...inputProps} />
-              <pre data-testid="meta">{JSON.stringify(meta)}</pre>
-              <pre data-testid="renders">{JSON.stringify(renders)}</pre>
-            </div>
-          );
-        }}
-      />,
-      { wrapper: TestWrapper }
-    ));
+  describe('base', () => {
+    beforeEach(() => {
+      ({ container } = render(
+        <PathFormField
+          path={['nested', 'items', 0, 'name']}
+          defaultValue="default"
+          render={({ inputProps, meta, renders }) => {
+            return (
+              <div>
+                <label htmlFor="name">Name</label>
+                <input id="name" {...inputProps} />
+                <pre data-testid="meta">{JSON.stringify(meta)}</pre>
+                <pre data-testid="renders">{JSON.stringify(renders)}</pre>
+              </div>
+            );
+          }}
+        />,
+        { wrapper: TestWrapper }
+      ));
+    });
+
+    it('renders with the value from the store', async () => {
+      expect(getByTestId(container, 'meta')).toMatchSnapshot();
+      expect(getByLabelText(container, 'Name')).toHaveDisplayValue('Joey Joe Joe Jr. Shabadoo');
+      expect(getByTestId(container, 'renders')).toMatchSnapshot();
+    });
+
+    it('user can type and modify the value in the store', async () => {
+      userEvent.click(getByLabelText(container, 'Name'));
+      userEvent.type(getByLabelText(container, 'Name'), ' new text');
+
+      // new text appended
+      expect(getByLabelText(container, 'Name')).toHaveDisplayValue(/ new text$/);
+
+      // rendered 9 times due to typing 9 characters
+      expect(getByTestId(container, 'renders')).toHaveTextContent('9');
+    });
   });
 
-  it('renders with the value from the store', async () => {
-    expect(getByTestId(container, 'meta')).toMatchInlineSnapshot(`
-      <pre
-        data-testid="meta"
-      >
-        {"uuid":"uuid-3","dirty":false,"touched":false,"error":null,"validations":null,"defaultValue":"Joey Joe Joe Jr. Shabadoo"}
-      </pre>
-    `);
-    expect(getByLabelText(container, 'Name')).toHaveDisplayValue('Joey Joe Joe Jr. Shabadoo');
-    expect(getByTestId(container, 'renders')).toMatchInlineSnapshot(`
-      <pre
-        data-testid="renders"
-      >
-        0
-      </pre>
-    `);
-  });
+  describe('validations', () => {
+    it('adds an error when custom validation returns false', async () => {
+      const { container } = render(
+        <PathFormField
+          path={['nested', 'items', 0, 'name']}
+          defaultValue="default"
+          validations={[
+            {
+              type: 'custom',
+              message: 'Not a real name',
+              value: (value: string) => {
+                // asdasdasd is not a real name, returns false if the name contains it
+                return value.indexOf('asdasdasd') === -1;
+              },
+            },
+          ]}
+          render={({ inputProps, meta, renders }) => {
+            return (
+              <div>
+                <label htmlFor="name">Name</label>
+                <input id="name" {...inputProps} />
+                <pre data-testid="meta">{JSON.stringify(meta)}</pre>
+                <pre data-testid="renders">{JSON.stringify(renders)}</pre>
+              </div>
+            );
+          }}
+        />,
+        { wrapper: TestWrapper }
+      );
 
-  it('user can type and modify the value in the store', async () => {
-    userEvent.click(getByLabelText(container, 'Name'));
-    userEvent.type(getByLabelText(container, 'Name'), ' new text');
+      userEvent.click(getByLabelText(container, 'Name'));
+      userEvent.type(getByLabelText(container, 'Name'), ' asdasdasd');
 
-    // new text appended
-    expect(getByLabelText(container, 'Name')).toHaveDisplayValue(/ new text$/);
+      userEvent.click(getByTestId(container, 'submit'));
 
-    // rendered 9 times due to typing 9 characters
-    expect(getByTestId(container, 'renders')).toHaveTextContent('9');
+      expect(getByTestId(container, 'meta')).toMatchSnapshot();
+    });
+
+    it('adds an error when another value on the store is invalid', async () => {
+      const { container } = render(
+        <PathFormField
+          path={['nested', 'items', 0, 'name']}
+          defaultValue="default"
+          validations={[
+            {
+              type: 'custom',
+              message: 'Some other item is invalid',
+              value: (_value, store) => {
+                return store.someToggle;
+              },
+            },
+          ]}
+          render={({ inputProps, meta, renders }) => {
+            return (
+              <div>
+                <label htmlFor="name">Name</label>
+                <input id="name" {...inputProps} />
+                <pre data-testid="meta">{JSON.stringify(meta)}</pre>
+                <pre data-testid="renders">{JSON.stringify(renders)}</pre>
+              </div>
+            );
+          }}
+        />,
+        { wrapper: TestWrapper }
+      );
+
+      userEvent.click(getByLabelText(container, 'Name'));
+      userEvent.type(getByLabelText(container, 'Name'), ' asdasdasd');
+
+      userEvent.click(getByTestId(container, 'submit'));
+
+      expect(getByTestId(container, 'meta')).toMatchSnapshot();
+    });
   });
 });

--- a/src/__snapshots__/PathFormField.test.tsx.snap
+++ b/src/__snapshots__/PathFormField.test.tsx.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PathFormField base renders with the value from the store 1`] = `
+<pre
+  data-testid="meta"
+>
+  {"uuid":"uuid-3","dirty":false,"touched":false,"error":null,"validations":null,"defaultValue":"Joey Joe Joe Jr. Shabadoo"}
+</pre>
+`;
+
+exports[`PathFormField base renders with the value from the store 2`] = `
+<pre
+  data-testid="renders"
+>
+  0
+</pre>
+`;
+
+exports[`PathFormField validations adds an error when another value on the store is invalid 1`] = `
+<pre
+  data-testid="meta"
+>
+  {"uuid":"uuid-3","dirty":true,"touched":true,"error":{"type":"custom","message":"Some other item is invalid"},"validations":[{"type":"custom","message":"Some other item is invalid"}],"defaultValue":"Joey Joe Joe Jr. Shabadoo"}
+</pre>
+`;
+
+exports[`PathFormField validations adds an error when custom validation returns false 1`] = `
+<pre
+  data-testid="meta"
+>
+  {"uuid":"uuid-3","dirty":true,"touched":true,"error":{"type":"custom","message":"Not a real name"},"validations":[{"type":"custom","message":"Not a real name"}],"defaultValue":"Joey Joe Joe Jr. Shabadoo"}
+</pre>
+`;

--- a/src/usePathForm.tsx
+++ b/src/usePathForm.tsx
@@ -51,7 +51,8 @@ export type PathFormStoreSetMeta = Partial<Omit<PathFormStoreMeta, 'uuid'>>;
 export type PathFormValidation =
   | { type: 'required'; message: string }
   | { type: 'minLength' | 'maxLength' | 'min' | 'max'; value: number; message: string }
-  | { type: 'regex'; value: RegExp; message: string };
+  | { type: 'regex'; value: RegExp; message: string }
+  | { type: 'custom'; value: (value: any, store?: any) => boolean; message: string };
 
 export type PathFormValueType = 'primitive' | 'object' | 'array';
 
@@ -198,7 +199,11 @@ export const PathFormProvider: React.FC<PathFormProviderProps> = ({ children, in
           return;
         }
 
-        if (storeItem.type === 'primitive') {
+        if (validation.type === 'custom') {
+          if (!(validation.value && validation.value(storeItem.value, getValues()))) {
+            addError(path, validation);
+          }
+        } else if (storeItem.type === 'primitive') {
           if (validation.type === 'required') {
             if (storeItem.value === null || (typeof storeItem.value === 'string' && storeItem.value === '')) {
               addError(path, validation);


### PR DESCRIPTION
## Summary
This PR is meant to add a custom validation in addition to the other types of validation.

## Changes
- Add a custom validation type, it runs a function that receives the current value and the store (to be able to compare with other fields)
- Don't clear the errors on blue
- Updated documentation
- Updated the example page
- Add the error validation unit tests

## Example
![image](https://user-images.githubusercontent.com/191252/175186321-7865e63e-9cd8-4eb4-ac11-4e8c564c889c.png)