### PR TITLE
Add the form validation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,13 @@ The data in the store will remain until the `PathFormProvider` is unmounted.
 
 The initial data for your form on the *initial render only*.
 
+#### PathFormProvider `mode?: 'onSubmit' | 'onChange'`
+
+Set the mode in which the validation will happen.
+
+- onSubmit (default): will run the validation when the form is submitted.
+- onChange: Validation will trigger on the change event with each input, this may trigger multiple rerenders. The PathForm.onValidate will continue to be triggered on the submit event.
+
 <br/><br/>
 
 ### PathForm

--- a/example/src/ExampleApp.tsx
+++ b/example/src/ExampleApp.tsx
@@ -5,7 +5,15 @@ import DeleteIcon from '@material-ui/icons/DeleteRounded';
 import ArrowUpIcon from '@material-ui/icons/ArrowUpwardRounded';
 import ArrowDownIcon from '@material-ui/icons/ArrowDownwardRounded';
 
-import { PathForm, PathFormArray, PathFormField, PathFormProvider, usePathForm, usePathFormValue } from '../../dist';
+import {
+  PathForm,
+  PathFormArray,
+  PathFormField,
+  PathFormProvider,
+  usePathForm,
+  usePathFormValue,
+  PathFormValidationMode,
+} from '../../dist';
 import { PathFormDevTools } from './ExamplePathFormDevTools';
 
 const fetchedData = {
@@ -17,25 +25,57 @@ const fetchedData = {
 };
 
 export const ExampleApp = () => {
+  const [mode, setMode] = React.useState<PathFormValidationMode>('onSubmit');
+
+  // This will force the form to be removed and added back to the tree, this way it's possible to change the mode
+  const [showForm, setShowForm] = React.useState(true);
+  React.useEffect(() => {
+    if (!showForm) {
+      const timeout = setTimeout(() => setShowForm(true), 100);
+      return () => clearTimeout(timeout);
+    }
+  }, [showForm]);
+
+  const onChangeMode = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setMode(e.target.value as PathFormValidationMode);
+    setShowForm(false);
+  };
+
   return (
-    <PathFormProvider initialRenderValues={fetchedData}>
-      <div style={{ display: 'flex', height: '100vh' }}>
-        <div style={{ width: 800, padding: 25 }}>
-          <div style={{ marginBottom: 50 }}>
-            <h2>Validations</h2>
-            <ul>
-              <li>Must have a name</li>
-              <li>Name can't be 'Joe'</li>
-              <li>Age must be 21 or older</li>
-            </ul>
-          </div>
-          <MyForm />
-        </div>
-        <aside style={{ flex: 1, overflowY: 'scroll', padding: 25 }}>
-          <PathFormDevTools />
-        </aside>
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <div style={{ padding: 16, margin: 16, border: '1px solid #AAA', borderRadius: 8, backgroundColor: '#F0F0F0' }}>
+        <p style={{ margin: 0 }}>
+          <strong>Form rules</strong>
+        </p>
+        <label>
+          Select validation mode:
+          <select style={{ marginLeft: 8 }} onChange={onChangeMode}>
+            <option value="onSubmit">onSubmit</option>
+            <option value="onChange">onChange</option>
+          </select>
+        </label>
       </div>
-    </PathFormProvider>
+      {showForm && (
+        <PathFormProvider initialRenderValues={fetchedData} mode={mode}>
+          <div style={{ display: 'flex', flexGrow: 1, height: '100%' }}>
+            <div style={{ width: 800, padding: 25 }}>
+              <div style={{ marginBottom: 50 }}>
+                <h2>Validations</h2>
+                <ul>
+                  <li>Must have a name</li>
+                  <li>Name can't be 'Joe'</li>
+                  <li>Age must be 21 or older</li>
+                </ul>
+              </div>
+              <MyForm />
+            </div>
+            <aside style={{ flex: 1, overflowY: 'scroll' }}>
+              <PathFormDevTools />
+            </aside>
+          </div>
+        </PathFormProvider>
+      )}
+    </div>
   );
 };
 

--- a/src/PathFormField.tsx
+++ b/src/PathFormField.tsx
@@ -35,7 +35,7 @@ export interface PathFormFieldProps {
 export const PathFormField: React.FC<PathFormFieldProps> = ({ path, render, defaultValue, validations, publish }) => {
   const name = usePathFormDotPath(path);
   const [value, meta, renders] = usePathFormValue(path, defaultValue); // TODO defaultValue needed?
-  const { setValue, setMeta, clearError, watchers } = usePathForm();
+  const { setValue, setMeta, clearError, watchers, state } = usePathForm();
 
   const onChange = React.useCallback(
     (event: any) => {
@@ -62,7 +62,7 @@ export const PathFormField: React.FC<PathFormFieldProps> = ({ path, render, defa
       const blurValue = event?.target?.value ?? event;
 
       // if the field has an error, and our blur value is different than the error value, clear the error
-      if (Boolean(meta?.error) && blurValue !== meta?.error?.value) {
+      if (Boolean(meta?.error) && blurValue !== meta?.error?.value && state.current.mode !== 'onChange') {
         clearError(path);
       }
 
@@ -70,7 +70,7 @@ export const PathFormField: React.FC<PathFormFieldProps> = ({ path, render, defa
         setMeta(path, { touched: true });
       }
     },
-    [path, clearError, setMeta, meta]
+    [path, clearError, setMeta, meta, state.current.mode]
   );
 
   // TODO reusable hook for usePathFormValidation -> useEffect [validations]

--- a/src/__snapshots__/PathFormField.test.tsx.snap
+++ b/src/__snapshots__/PathFormField.test.tsx.snap
@@ -16,7 +16,39 @@ exports[`PathFormField base renders with the value from the store 2`] = `
 </pre>
 `;
 
-exports[`PathFormField validations adds an error when another value on the store is invalid 1`] = `
+exports[`PathFormField onChange validations adds an error when another value on the store is invalid 1`] = `
+<pre
+  data-testid="meta"
+>
+  {"uuid":"uuid-3","dirty":true,"touched":false,"error":{"type":"custom","message":"Some other item is invalid"},"validations":[{"type":"custom","message":"Some other item is invalid"}],"defaultValue":"Joey Joe Joe Jr. Shabadoo"}
+</pre>
+`;
+
+exports[`PathFormField onChange validations adds an error when custom validation returns false 1`] = `
+<pre
+  data-testid="meta"
+>
+  {"uuid":"uuid-3","dirty":true,"touched":false,"error":{"type":"custom","message":"Not a real name"},"validations":[{"type":"custom","message":"Not a real name"}],"defaultValue":"Joey Joe Joe Jr. Shabadoo"}
+</pre>
+`;
+
+exports[`PathFormField onChange validations clears the error when it's fixed 1`] = `
+<pre
+  data-testid="meta"
+>
+  {"uuid":"uuid-3","dirty":true,"touched":false,"error":{"type":"required","message":"Field is required"},"validations":[{"type":"required","message":"Field is required"}],"defaultValue":"Joey Joe Joe Jr. Shabadoo"}
+</pre>
+`;
+
+exports[`PathFormField onChange validations clears the error when it's fixed 2`] = `
+<pre
+  data-testid="meta"
+>
+  {"uuid":"uuid-3","dirty":true,"touched":false,"error":null,"validations":[{"type":"required","message":"Field is required"}],"defaultValue":"Joey Joe Joe Jr. Shabadoo"}
+</pre>
+`;
+
+exports[`PathFormField onSubmit validations adds an error when another value on the store is invalid 1`] = `
 <pre
   data-testid="meta"
 >
@@ -24,7 +56,7 @@ exports[`PathFormField validations adds an error when another value on the store
 </pre>
 `;
 
-exports[`PathFormField validations adds an error when custom validation returns false 1`] = `
+exports[`PathFormField onSubmit validations adds an error when custom validation returns false 1`] = `
 <pre
   data-testid="meta"
 >

--- a/src/usePathForm.tsx
+++ b/src/usePathForm.tsx
@@ -17,11 +17,14 @@ import { noDifference } from './utils';
 
 export type PathFormValuePrimitive = string | number | boolean | null;
 
+export type PathFormValidationMode = 'onSubmit' | 'onChange';
+
 export type PathFormState = {
   store: PathFormStore;
   dirtyUuids: string[];
   errors: PathFormStoreItemFlat[];
   defaultValues: any;
+  mode: PathFormValidationMode;
 };
 
 export type PathFormPath = Array<string | number>; // | string;
@@ -142,15 +145,18 @@ PathFormStateContext.displayName = 'PathFormStateContext';
 export interface PathFormProviderProps {
   initialRenderValues?: any; // TODO generics or something
   children: React.ReactNode;
+  mode?: PathFormValidationMode;
 }
 
-export const PathFormProvider: React.FC<PathFormProviderProps> = ({ children, initialRenderValues }) => {
+export const PathFormProvider: React.FC<PathFormProviderProps> = ({ children, initialRenderValues, mode = 'onSubmit' }) => {
   const state = React.useRef<PathFormState>({
     store: createStore(initialRenderValues),
     dirtyUuids: [],
     errors: [],
     defaultValues: initialRenderValues,
+    mode,
   });
+
   const watchers = React.useRef(eventEmitter());
 
   const getValues = () => {
@@ -191,44 +197,56 @@ export const PathFormProvider: React.FC<PathFormProviderProps> = ({ children, in
       throw new Error(`The target path "${dotpath}" does not exist.`);
     }
 
+    const canClearErrors = state.current.mode === 'onChange';
+
     if (storeItem.meta.validations) {
+      let hasError = !!storeItem.meta.error;
+      canClearErrors && (hasError = false);
+
       storeItem.meta.validations.forEach((validation) => {
         // do nothing if the store item already has a validation error
         // TODO this may eventually get eliminated once a field can have multiple errors
-        if (storeItem.meta.error) {
+        if (hasError) {
           return;
         }
 
         if (validation.type === 'custom') {
           if (!(validation.value && validation.value(storeItem.value, getValues()))) {
             addError(path, validation);
+            hasError = true;
           }
         } else if (storeItem.type === 'primitive') {
           if (validation.type === 'required') {
             if (storeItem.value === null || (typeof storeItem.value === 'string' && storeItem.value === '')) {
               addError(path, validation);
+              hasError = true;
             }
           } else if (validation.type === 'min') {
             if (Number(storeItem.value) < validation.value) {
               addError(path, validation);
+              hasError = true;
             }
           } else if (validation.type === 'max') {
             if (Number(storeItem.value) > validation.value) {
               addError(path, validation);
+              hasError = true;
             }
           } else if (validation.type === 'minLength') {
             if (typeof storeItem.value === 'string' && storeItem.value.length < validation.value) {
               addError(path, validation);
+              hasError = true;
             }
           } else if (validation.type === 'maxLength') {
             if (typeof storeItem.value === 'string' && storeItem.value.length > validation.value) {
               addError(path, validation);
+              hasError = true;
             }
           } else if (validation.type === 'regex') {
             try {
               const regex = validation.value;
               if (typeof storeItem.value === 'string' && !regex.test(storeItem.value)) {
                 addError(path, validation);
+                hasError = true;
               }
             } catch (err) {
               // could not compile regex
@@ -238,14 +256,18 @@ export const PathFormProvider: React.FC<PathFormProviderProps> = ({ children, in
           if (validation.type === 'minLength') {
             if (storeItem.value.length < validation.value) {
               addError(path, validation);
+              hasError = true;
             }
           } else if (validation.type === 'maxLength') {
             if (storeItem.value.length > validation.value) {
               addError(path, validation);
+              hasError = true;
             }
           }
         }
       });
+
+      canClearErrors && !hasError && clearError(path);
     } else {
       // clearError(path);
     }
@@ -301,6 +323,9 @@ export const PathFormProvider: React.FC<PathFormProviderProps> = ({ children, in
       }
 
       set(state.current.store, [...storePath, 'meta', 'dirty'], dirty);
+
+      // Validate field immediately on onChange mode
+      if (state.current.mode === 'onChange') validate(path);
 
       watchers.current.emit(toDotPath(path), value);
     }

--- a/src/usePathForm.tsx
+++ b/src/usePathForm.tsx
@@ -200,53 +200,45 @@ export const PathFormProvider: React.FC<PathFormProviderProps> = ({ children, in
     const canClearErrors = state.current.mode === 'onChange';
 
     if (storeItem.meta.validations) {
-      let hasError = !!storeItem.meta.error;
-      canClearErrors && (hasError = false);
+      canClearErrors && storeItem.meta.error && clearError(path);
 
       storeItem.meta.validations.forEach((validation) => {
         // do nothing if the store item already has a validation error
         // TODO this may eventually get eliminated once a field can have multiple errors
-        if (hasError) {
+        if (storeItem.meta.error) {
           return;
         }
 
         if (validation.type === 'custom') {
           if (!(validation.value && validation.value(storeItem.value, getValues()))) {
             addError(path, validation);
-            hasError = true;
           }
         } else if (storeItem.type === 'primitive') {
           if (validation.type === 'required') {
             if (storeItem.value === null || (typeof storeItem.value === 'string' && storeItem.value === '')) {
               addError(path, validation);
-              hasError = true;
             }
           } else if (validation.type === 'min') {
             if (Number(storeItem.value) < validation.value) {
               addError(path, validation);
-              hasError = true;
             }
           } else if (validation.type === 'max') {
             if (Number(storeItem.value) > validation.value) {
               addError(path, validation);
-              hasError = true;
             }
           } else if (validation.type === 'minLength') {
             if (typeof storeItem.value === 'string' && storeItem.value.length < validation.value) {
               addError(path, validation);
-              hasError = true;
             }
           } else if (validation.type === 'maxLength') {
             if (typeof storeItem.value === 'string' && storeItem.value.length > validation.value) {
               addError(path, validation);
-              hasError = true;
             }
           } else if (validation.type === 'regex') {
             try {
               const regex = validation.value;
               if (typeof storeItem.value === 'string' && !regex.test(storeItem.value)) {
                 addError(path, validation);
-                hasError = true;
               }
             } catch (err) {
               // could not compile regex
@@ -256,18 +248,14 @@ export const PathFormProvider: React.FC<PathFormProviderProps> = ({ children, in
           if (validation.type === 'minLength') {
             if (storeItem.value.length < validation.value) {
               addError(path, validation);
-              hasError = true;
             }
           } else if (validation.type === 'maxLength') {
             if (storeItem.value.length > validation.value) {
               addError(path, validation);
-              hasError = true;
             }
           }
         }
       });
-
-      canClearErrors && !hasError && clearError(path);
     } else {
       // clearError(path);
     }


### PR DESCRIPTION
## Summary
This PR is meant to add an onChange validation mode in addition to the default onSubmit.

## Changes
- [x] onChange validation mode makes it run the input validation on every onChange event
- [x] Update the docs
- [x] Update the example
- [x] Unit tests

## Example
https://user-images.githubusercontent.com/191252/175195875-0ed73edb-ab58-4e8d-93bd-be76db306af7.mp4
