### PR TITLE
Validate the field when mounted

### DIFF
--- a/example/src/ExampleApp.tsx
+++ b/example/src/ExampleApp.tsx
@@ -27,18 +27,8 @@ const fetchedData = {
 export const ExampleApp = () => {
   const [mode, setMode] = React.useState<PathFormValidationMode>('onSubmit');
 
-  // This will force the form to be removed and added back to the tree, this way it's possible to change the mode
-  const [showForm, setShowForm] = React.useState(true);
-  React.useEffect(() => {
-    if (!showForm) {
-      const timeout = setTimeout(() => setShowForm(true), 100);
-      return () => clearTimeout(timeout);
-    }
-  }, [showForm]);
-
   const onChangeMode = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setMode(e.target.value as PathFormValidationMode);
-    setShowForm(false);
   };
 
   return (
@@ -55,26 +45,24 @@ export const ExampleApp = () => {
           </select>
         </label>
       </div>
-      {showForm && (
-        <PathFormProvider initialRenderValues={fetchedData} mode={mode}>
-          <div style={{ display: 'flex', flexGrow: 1, height: '100%' }}>
-            <div style={{ width: 800, padding: 25 }}>
-              <div style={{ marginBottom: 50 }}>
-                <h2>Validations</h2>
-                <ul>
-                  <li>Must have a name</li>
-                  <li>Name can't be 'Joe'</li>
-                  <li>Age must be 21 or older</li>
-                </ul>
-              </div>
-              <MyForm />
+      <PathFormProvider initialRenderValues={fetchedData} mode={mode} key={mode}>
+        <div style={{ display: 'flex', flexGrow: 1, height: '100%' }}>
+          <div style={{ width: 800, padding: 25 }}>
+            <div style={{ marginBottom: 50 }}>
+              <h2>Validations</h2>
+              <ul>
+                <li>Must have a name</li>
+                <li>Name can't be 'Joe'</li>
+                <li>Age must be 21 or older</li>
+              </ul>
             </div>
-            <aside style={{ flex: 1, overflowY: 'scroll' }}>
-              <PathFormDevTools />
-            </aside>
+            <MyForm />
           </div>
-        </PathFormProvider>
-      )}
+          <aside style={{ flex: 1, overflowY: 'scroll' }}>
+            <PathFormDevTools />
+          </aside>
+        </div>
+      </PathFormProvider>
     </div>
   );
 };

--- a/src/PathFormField.tsx
+++ b/src/PathFormField.tsx
@@ -35,7 +35,7 @@ export interface PathFormFieldProps {
 export const PathFormField: React.FC<PathFormFieldProps> = ({ path, render, defaultValue, validations, publish }) => {
   const name = usePathFormDotPath(path);
   const [value, meta, renders] = usePathFormValue(path, defaultValue); // TODO defaultValue needed?
-  const { setValue, setMeta, clearError, watchers, state } = usePathForm();
+  const { setValue, setMeta, clearError, watchers, state, validate } = usePathForm();
 
   const onChange = React.useCallback(
     (event: any) => {
@@ -78,8 +78,9 @@ export const PathFormField: React.FC<PathFormFieldProps> = ({ path, render, defa
     // TODO handle multiple fields for same path
     if (validations) {
       setMeta(path, { validations });
+      if (state.current.mode === 'onChange') validate(path);
     }
-  }, [setMeta, validations]);
+  }, [setMeta, validations, validate, state.current.mode]);
 
   return render({
     inputProps: {


### PR DESCRIPTION
## Changes
Running the validation as soon as the field is set up or the validation rules changed.
This rule will only apply if the mode is onChange.

Additionally, I replaced the show form logic with a key on the example app. This accomplishes the same result in a cleaner way.


![image](https://user-images.githubusercontent.com/191252/175970955-7edc26f0-5abf-4c7c-9e83-ccaa07617aac.png)
